### PR TITLE
コンテキストメニューをキー操作に対応

### DIFF
--- a/src/Constants.py
+++ b/src/Constants.py
@@ -86,3 +86,8 @@ CONTEXT_MENU_HOVERD_BACKGROUND_COLOR = (241, 243, 245)
 """tuple[int, int, int]: コンテキストメニューがホバーされた時の要素の色"""
 CONTEXT_MENU_DIVIDER_COLOR = (200, 200, 200)
 """tuple[int, int, int]: コンテキストメニューの区切り線の色"""
+
+LONG_PRESS_START_MILLISEC = 500
+"""int: ロングプレス判定の開始時間"""
+LONG_PRESS_INTERVAL_MILLISEC = 100
+"""int: ロングプレス判定の間隔"""

--- a/src/Model/ContextMenu/ButtonBase.py
+++ b/src/Model/ContextMenu/ButtonBase.py
@@ -63,6 +63,14 @@ class ButtonBase(ClickAble):
         """ボタンを有効化します。"""
         self.a_enable = True
 
+    def enable_status(self) -> bool:
+        """ボタンが有効かどうかを取得します。
+
+        Returns:
+            bool: ボタンが有効かどうか
+        """
+        return self.a_enable
+
     def text(self) -> str:
         """ボタンのテキストを取得します。
 
@@ -72,6 +80,13 @@ class ButtonBase(ClickAble):
         return self.a_text
 
     def hover_in(self) -> None:
+        self.focus()
+
+    def hover_out(self) -> None:
+        self.un_focus()
+
+    def focus(self) -> None:
+        """ボタンにフォーカスを当てます。"""
         if self.a_enable:
             rect = self.container.get_rect()
 
@@ -81,7 +96,8 @@ class ButtonBase(ClickAble):
             self.background_color = CONTEXT_MENU_HOVERD_BACKGROUND_COLOR
             self.render(rect.x, rect.y, rect.width, rect.height)
 
-    def hover_out(self) -> None:
+    def un_focus(self) -> None:
+        """ボタンのフォーカスを外します。"""
         rect = self.container.get_rect()
 
         if self.container.is_rendered():


### PR DESCRIPTION
# このPRについて
このPRは、アプリ内でスタンドアロン版とweb版の環境差分を吸収するためにpygameの描画機能を利用して実装されたコンテキストメニューをキーボード操作可能にするものです。
ctl + 左クリック(mac標準)やshift + Fn10(windows標準) でコンテキストメニューを展開できるようになります。  
また、↑↓矢印キーでコンテキストメニューのボタンを選択できるようになります。  長押しで次々とフォーカスを移動する操作にも対応。  
矢印キーで選択したボタンは、Enterキーを押下することで押下できます。

- ButtonBaseをfocusできるように、```focus```,```un_focus```メソッドを追加。
- ContextMenuモデルに、動的に生成された各コンテキストボタンの中で、次のボタンをフォーカスする```next_button_focus```メソッドと、前のボタンをフォーカスする```prev_button_focus```メソッドを追加。これらのメソッドはdisable状態のボタンを飛ばして（ないものとみなして）フォーカス操作ができるようになっています。
- ContextMenuモデルに、現在フォーカスしているボタンを実行する```has_focused_button_enter```メソッドを追加。
- SpiroControllerに以下のコードを追加
    - ```key_down_event```を処理し、各モデルにメッセージを発信するコード
    - ```key_up_event```を処理するコード
    - key_downの記録及び制御により、keyの長押しを検出し、イベントとして扱う```key_long_down_event```メソッドの追加
- Constantsに長押しの判定時間及び、長押しのインターバル時間を表す定数を追加