### PR TITLE
スピード調整ダイアログの追加

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -35,7 +35,7 @@ buildもしくは[web版](https://www.cc.kyoto-su.ac.jp/~g2154352/SpiroDesignWeb
 
 コンテキストメニューは、各メニューボタンをマウスでクリックするか、↑↓矢印キーでボタンを選び、Enterを押すことで押下できます。
 
-<img width="154" alt="スクリーンショット 2023-11-21 17 58 52" src="https://github.com/YomogiBeta/SpiroDesign_by_Copilot/assets/46161490/3dd223d2-6ec6-4d04-b8cd-d16178115b96">
+<img width="157" alt="スクリーンショット 2024-06-05 0 04 14" src="https://github.com/YomogiBeta/SpiroDesign_by_Copilot/assets/46161490/90668ec4-c3ab-4bd7-8c53-32d9b2448d39">
 
 |項目| 説明|
 |:----|:----|
@@ -45,6 +45,7 @@ buildもしくは[web版](https://www.cc.kyoto-su.ac.jp/~g2154352/SpiroDesignWeb
 |clear| 現在描画中であるかどうかに関わらず、スパーギア(赤円)の範囲にある描画を全てクリアします。|
 |speed_up|  シュミレーション速度をあげます。|
 |speed_down|  シュミレーション速度を下げます。|
+|set_speed|  シュミレーション速度を指定するダイアログを開きます。|
 |color| ペンの色を変更するダイアログを開きます。|
 |rainbow| ペンの色を虹色に遷移させるモードをONにします。ペン色を変更するとOFFになります。|
 |nib| ペンの太さを変更するダイアログを開きます。|

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -53,7 +53,7 @@ PINION_GEAR_COLOR = (0, 0, 255)
 GEAR_LINE_COLOR = (0, 255, 0)
 """tuple[int, int, int]: 補助線の色"""
 
-MAX_SPEED = 10
+MAX_SPEED = 90
 """int: 最大速度"""
 MIN_SPEED = 1
 """int: 最小速度"""

--- a/src/Model/SpiroModel.py
+++ b/src/Model/SpiroModel.py
@@ -600,6 +600,23 @@ class SpiroModel:
         if self._an_add_angle <= MIN_SPEED:
             self._an_add_angle = MIN_SPEED
 
+    def set_speed(self, speed: int) -> None:
+        """アニメーションのスピードを設定する
+
+        Args:
+            speed (int): アニメーションのスピード
+        """
+        if MIN_SPEED <= speed <= MAX_SPEED:
+            self._an_add_angle = speed
+
+    def speed(self) -> int:
+        """現在のアニメーションスピードを返す
+
+        Returns:
+            int: 現在のアニメーションスピード
+        """
+        return self._an_add_angle
+
     def main_board_surface(self) -> pygame.Surface:
         """メインボードのSurfaceを返す
 

--- a/src/bridge_pyjs/ui_call/ScaleDialog.py
+++ b/src/bridge_pyjs/ui_call/ScaleDialog.py
@@ -4,9 +4,11 @@ from tkinter import LEFT
 
 
 class ScaleDialog(simpledialog.Dialog):
-    def __init__(self, master, callback, init_value: int) -> None:
+    def __init__(self, master, callback, min_number: int, max_number: int, init_value: int) -> None:
         self.a_callback = callback
         self.a_init_value = init_value
+        self.a_min = min_number
+        self.a_max = max_number
         super(ScaleDialog, self).__init__(parent=master, title="Select Value")
 
     def body(self, master):
@@ -15,8 +17,8 @@ class ScaleDialog(simpledialog.Dialog):
 
         self.a_scale = Scale(master,
                              command=self.update_value_label,
-                             from_=2,
-                             to=10,
+                             from_=self.a_min,
+                             to=self.a_max,
                              length=320
                              )
         self.a_scale.set(self.a_init_value)

--- a/src/bridge_pyjs/ui_call/ui_call.py
+++ b/src/bridge_pyjs/ui_call/ui_call.py
@@ -146,16 +146,24 @@ def download_content(content, filename: str, mode='w') -> None:
     # downLoadLink.click()
 
 
-def askvalue(master, callback, init_value=1.0) -> None:
+def askvalue(master, callback, min_number, max_number, init_value=1.0) -> None:
     """スライドバーを開き、数値を引数のコールバック関数に渡す
 
     Args:
+        master (tk.Tk):
+            ルートウィンドウ
         callback (Callable[[float], None]):
             数値を引数に取るコールバック関数
+        min (int):
+            最小値
+        max (int):
+            最大値
+        init_value (float, optional):
+            初期値. デフォルトは 1.0 .
     """
 
     # Python
-    ScaleDialog(master, callback, init_value)
+    ScaleDialog(master, callback, min_number, max_number, init_value)
 
     # Javascript
     # slider_panel = document.getElementById('slider-panel')
@@ -165,6 +173,10 @@ def askvalue(master, callback, init_value=1.0) -> None:
     # slider_panel.showModal()
     # slider.value = str(init_value)
     # slider_label.textContent = str(init_value)
+
+    # Javascript
+    # slider.min = min_number
+    # slider.max = max_number
 
     # Javascript
     # def select_value(e):

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from Model.SpiroModel import SpiroModel
 from View.SpiroView import SpiroView
 from View.UiView import UiView
 from bridge_pyjs import ui_call
+from bridge_pyjs.ParseIntBridge import parse_int
 from bridge_pyjs.PygameBridge import pygame, set_icon
 
 
@@ -37,6 +38,7 @@ def create_menu(context_menu: ContextMenu, spiro_model: SpiroModel, root) -> lis
         context_menu.enable_item("stop")
         context_menu.enable_item("speed_up")
         context_menu.enable_item("speed_down")
+        context_menu.enable_item("set_speed")
 
         context_menu.disable_item("color")
         context_menu.disable_item("nib")
@@ -54,6 +56,7 @@ def create_menu(context_menu: ContextMenu, spiro_model: SpiroModel, root) -> lis
         context_menu.enable_item("start")
         context_menu.disable_item("speed_up")
         context_menu.disable_item("speed_down")
+        context_menu.disable_item("set_speed")
 
         context_menu.enable_item("color")
         context_menu.enable_item("rainbow")
@@ -78,7 +81,13 @@ def create_menu(context_menu: ContextMenu, spiro_model: SpiroModel, root) -> lis
         def set_nib(nib: float):
             if nib is not None:
                 spiro_model.set_pen_nib(nib)
-        ui_call.askvalue(root, set_nib, spiro_model.pinion_gear().pen().width)
+        ui_call.askvalue(root, set_nib, 2, 10, spiro_model.pinion_gear().pen().width)
+
+    def set_speed():
+        def set_move_speed(speed: float):
+            if speed is not None:
+                spiro_model.set_speed(parse_int(speed))
+        ui_call.askvalue(root, set_move_speed, 1, 90, spiro_model.speed())
 
     def select_color():
         animationed = spiro_model.animation()
@@ -110,7 +119,8 @@ def create_menu(context_menu: ContextMenu, spiro_model: SpiroModel, root) -> lis
         },
         {
             "speed_up": spiro_model.speed_up,
-            "speed_down": spiro_model.speed_down
+            "speed_down": spiro_model.speed_down,
+            "set_speed": set_speed
         },
         {
             "color": select_color,

--- a/web_page/index.html
+++ b/web_page/index.html
@@ -21,7 +21,7 @@
     <!-- <input type="file" id="file_selector" /> -->
     <dialog id="slider-panel">
         <div class="panel">
-            <input type="range" id="slider" min="2" max="10" step="0.01" />
+            <input type="range" id="slider" step="0.01" />
             <output id="slider-label">None</output>
             <button class="mantine-button" id="slider-decide-button">OK</button>
         </div>


### PR DESCRIPTION
# このPRについて
スピロデザインのシュミレートのスピードを、スケールダイアログで調整可能にするものです。

- スケールダイアログの最小値と最大値を呼び出し元から変更できるように修正。（Python版、web版ともに）
- スピードを値を指定して設定できるメソッドを追加。
- コンテキストメニューに「set_speed」の項目を追加
- 最大設定可能速度を10から90に変更